### PR TITLE
[12] Setup .github template and README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,20 @@
+---
+name: "Bug Report"
+about: "You found something that is not working. Report it so that it can be fixed. 👷‍"
+title: "Fix: "
+labels: "type : bug"
+---
+
+## Issue
+
+Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
+
+## Expected
+
+Describe what should be the correct behaviour.
+
+## Steps to reproduce
+
+1.
+2.
+3.

--- a/.github/ISSUE_TEMPLATE/chore_template.md
+++ b/.github/ISSUE_TEMPLATE/chore_template.md
@@ -1,0 +1,14 @@
+---
+name: "Chore"
+about: "Open a Chore for minor update."
+title: "Update "
+labels: "type : chore"
+---
+
+## Why
+
+Describe the update details and why it's needed.
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,14 @@
+---
+name: "Feature"
+about: "Open a feature issue to add new functionalities."
+title: "Add "
+labels: "type : feature"
+---
+
+## Why
+
+Describe the big picture of the feature and why it's needed.
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...

--- a/.github/ISSUE_TEMPLATE/story_template.md
+++ b/.github/ISSUE_TEMPLATE/story_template.md
@@ -1,0 +1,22 @@
+---
+name: "Story"
+about: "Open a feature story"
+title: "[Type] As a user, I can "
+labels: "type : feature"
+---
+
+## Why
+
+Describe the idea of the user story as in what the motive of the user story is.
+
+## Acceptance Criteria
+
+List down how the user story will be tested and what criteria are necessary for the user story to be accepted.
+
+## Design
+
+(Optional) Add design screenshots or Figma links for UI/UX-related stories.
+
+## Resources
+
+(Optional) Add useful resources such as links to documentation, implementation ideas, or best practices.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+https://github.com/nimblehq/git-template/issues/??
+
+## What happened 👀
+
+Describe the big picture of your changes here to communicate to the team why we should accept this pull request.
+
+## Insight 📝
+
+Describe in details how to test the changes, which solution you tried but did not go with, referenced documentation is welcome as well.
+
+## Proof Of Work 📹
+
+Show us the implementation: screenshots, gif, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-https://github.com/nimblehq/git-template/issues/??
+https://github.com/nimblehq/android-common-ktx/issues/??
 
 ## What happened 👀
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,0 +1,17 @@
+Link to the milestone on Github e.g. https://github.com/nimblehq/git-templates/milestone/41?closed=1
+or
+Link to the project management tool for the release
+
+## Features
+
+Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
+
+- [ch1234] As a user, I can log in
+or
+- [[ch1234](https://github.com/nimblehq/git-templates/issues/1234)] As a user, I can log in
+
+## Chores
+- Same structure as in  ## Feature
+
+## Bugs
+- Same structure as in  ## Feature

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,4 +1,4 @@
-Link to the milestone on Github e.g. https://github.com/nimblehq/git-templates/milestone/41?closed=1
+Link to the milestone on Github e.g. https://github.com/nimblehq/android-common-ktx/milestone/1?closed=1
 or
 Link to the project management tool for the release
 
@@ -6,9 +6,9 @@ Link to the project management tool for the release
 
 Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
 
-- [ch1234] As a user, I can log in
+- [1234] As a user, I can log in
 or
-- [[ch1234](https://github.com/nimblehq/git-templates/issues/1234)] As a user, I can log in
+- [[1234](https://github.com/nimblehq/android-common-ktx/issues/1234)] As a user, I can log in
 
 ## Chores
 - Same structure as in  ## Feature

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Android Common Extensions
+
+This repository provides a collection of common Android extensions.
+
+## Usage
+
+Clone the repository
+
+`git clone git@github.com:nimblehq/android-common-ktx.git`
+
+## License
+
+This project is Copyright (c) 2014 and onwards. It is free software,
+and may be redistributed under the terms specified in the [LICENSE] file.
+
+[LICENSE]: /LICENSE
+
+## About
+
+![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
+
+This project is maintained and funded by Nimble.
+
+We love open source and do our part in sharing our work with the community!
+See [our other projects][community] or [hire our team][hire] to help build your product.
+
+[community]: https://github.com/nimblehq
+[hire]: https://nimblehq.co/


### PR DESCRIPTION
#12 

## What happened 👀
Add the `.github` templates for usage and init the first version of README

## Insight 📝
- Add `.github` templates
- Add `README.md`
 
## Proof Of Work 📹
The issue templates should be shown after merged and README on main page