### PR TITLE
[chore] Add code owner for automatically require review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These users will be requested for review when someone opens a pull request.
+*       @hoangnguyen92dn @lydiasama @doannimble


### PR DESCRIPTION
## What happened 👀

To reduce clicking when opening the PR, we can configure the reviewer on `CODEOWNERS` file.

## Insight 📝

- Add `CODEOWNERS` file

## Proof Of Work 📹

See the `Reviewers` section of the PR after merging this PR. 🤓 

