### PR TITLE
[#40] Fix: Project using this library build fail

### DIFF
--- a/common-ktx/src/main/AndroidManifest.xml
+++ b/common-ktx/src/main/AndroidManifest.xml
@@ -1,13 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.nimblehq.common.extensions">
-
-    <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.AndroidExtensions" />
-
-</manifest>
+<manifest package="co.nimblehq.common.extensions" />


### PR DESCRIPTION
https://github.com/nimblehq/android-common-ktx/issues/40

## What happened 👀

When adding this library to the android-templates, the error occurred:

> Execution failed for task ':app:processStagingDebugMainManifest'.
Manifest merger failed : Attribute application@theme value=(@style/AppTheme) from AndroidManifest.xml:16:9-40
is also present at [com.github.nimblehq:android-common-ktx:0.1.0] AndroidManifest.xml:15:9-55 value=(@style/Theme.AndroidExtensions).
Suggestion: add 'tools:replace="android:theme"' to element at AndroidManifest.xml:5:5-9:19 to override.

## Insight 📝

Remove unnecessary <application> in common-ktx/AndroidManifest.xml 

## Proof Of Work 📹

Project build success with build SNAPSHOT

https://user-images.githubusercontent.com/6950766/146338703-40d4e544-a78a-4355-af22-b2aa1bc7ac2b.mov

