### PR TITLE
[#49] Add a developer, I can avoid multiple clicks and navigation events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kover) apply false
     alias(libs.plugins.detekt)
 }

--- a/common-ktx/build.gradle.kts
+++ b/common-ktx/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
     id("maven-publish")
 }
 
@@ -33,9 +34,19 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    buildFeatures {
+        compose = true
+    }
+
     kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
+        }
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
         }
     }
 
@@ -52,11 +63,19 @@ dependencies {
     implementation(libs.material)
     implementation(libs.gson)
 
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.foundation)
+
     androidTestImplementation(libs.test.ext.junit)
     androidTestImplementation(libs.test.espresso.core)
     androidTestImplementation(libs.test.hamcrest)
 
     testImplementation(libs.test.junit)
+    testImplementation(libs.test.robolectric)
+    testImplementation(platform(libs.compose.bom))
+    testImplementation(libs.compose.ui.test.junit4)
+
+    debugImplementation(libs.compose.ui.test.manifest)
 }
 
 afterEvaluate {

--- a/common-ktx/src/main/java/co/nimblehq/common/extensions/compose/ModifierExt.kt
+++ b/common-ktx/src/main/java/co/nimblehq/common/extensions/compose/ModifierExt.kt
@@ -1,0 +1,114 @@
+package co.nimblehq.common.extensions.compose
+
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * A throttled clickable modifier that prevents multiple clicks in a short period.
+ *
+ * Usage:
+ * ```
+ * Button(
+ *     modifier = Modifier.throttleClickable { viewModel.submit() }
+ * )
+ *
+ * // With custom interval
+ * Button(
+ *     modifier = Modifier.throttleClickable(intervalMillis = 1000L) {
+ *         viewModel.submit()
+ *     }
+ * )
+ * ```
+ *
+ * @param enabled Whether the click is enabled.
+ * @param intervalMillis The minimum interval between clicks in milliseconds. Default is 500ms.
+ * @param onClick The callback to invoke when the click is not throttled.
+ *
+ * Reference: https://stackoverflow.com/a/72117388/3598447
+ */
+inline fun Modifier.throttleClickable(
+    enabled: Boolean = true,
+    intervalMillis: Long = 500L,
+    crossinline onClick: () -> Unit,
+): Modifier = composed {
+    throttleClickable(
+        interactionSource = null,
+        indication = null,
+        enabled = enabled,
+        intervalMillis = intervalMillis,
+        onClick = onClick,
+    )
+}
+
+/**
+ * A throttled clickable modifier with custom interaction source and indication.
+ * Use this when you need to control the ripple effect separately from the clickable area.
+ *
+ * Usage:
+ * ```
+ * val interactionSource = remember { MutableInteractionSource() }
+ *
+ * Box(
+ *     modifier = Modifier.throttleClickable(
+ *         interactionSource = interactionSource,
+ *         indication = ripple(),
+ *     ) {
+ *         viewModel.submit()
+ *     }
+ * )
+ *
+ * // Pass null to skip the ripple effect
+ * Box(
+ *     modifier = Modifier.throttleClickable(
+ *         interactionSource = interactionSource,
+ *         indication = null,
+ *     ) {
+ *         viewModel.submit()
+ *     }
+ * )
+ * ```
+ *
+ * @param interactionSource The [MutableInteractionSource] to dispatch interaction events to.
+ * @param indication The [Indication] to draw when the modifier is interacted with, or null to skip.
+ * @param enabled Whether the click is enabled.
+ * @param intervalMillis The minimum interval between clicks in milliseconds. Default is 500ms.
+ * @param onClick The callback to invoke when the click is not throttled.
+ *
+ * Reference: https://stackoverflow.com/a/72117388/3598447
+ */
+inline fun Modifier.throttleClickable(
+    interactionSource: MutableInteractionSource?,
+    indication: Indication?,
+    enabled: Boolean = true,
+    intervalMillis: Long = 500L,
+    crossinline onClick: () -> Unit,
+): Modifier = composed {
+    var throttled by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+    this.clickable(
+        interactionSource = interactionSource,
+        indication = indication,
+        enabled = enabled,
+    ) {
+        if (!throttled) {
+            throttled = true
+            onClick()
+            coroutineScope.launch {
+                delay(intervalMillis)
+                throttled = false
+            }
+        }
+    }
+}

--- a/common-ktx/src/test/java/co/nimblehq/common/extensions/compose/ModifierExtTest.kt
+++ b/common-ktx/src/test/java/co/nimblehq/common/extensions/compose/ModifierExtTest.kt
@@ -1,0 +1,194 @@
+package co.nimblehq.common.extensions.compose
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ModifierExtTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // region throttleClickable (basic)
+
+    @Test
+    fun `When clicking once, it registers the click`() {
+        var clickCount = 0
+        composeTestRule.setContent {
+            Box(
+                modifier = Modifier
+                    .testTag("button")
+                    .throttleClickable { clickCount++ }
+            )
+        }
+
+        composeTestRule.onNodeWithTag("button").performClick()
+
+        assertEquals(1, clickCount)
+    }
+
+    @Test
+    fun `When clicking rapidly, it registers only the first click`() {
+        var clickCount = 0
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            Box(
+                modifier = Modifier
+                    .testTag("button")
+                    .throttleClickable { clickCount++ }
+            )
+        }
+
+        composeTestRule.onNodeWithTag("button")
+            .performClick()
+            .performClick()
+            .performClick()
+
+        assertEquals(1, clickCount)
+    }
+
+    @Test
+    fun `When clicking after the interval has passed, it registers the click again`() {
+        var clickCount = 0
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            Box(
+                modifier = Modifier
+                    .testTag("button")
+                    .throttleClickable(intervalMillis = 100L) { clickCount++ }
+            )
+        }
+
+        composeTestRule.onNodeWithTag("button").performClick()
+        assertEquals(1, clickCount)
+
+        composeTestRule.mainClock.advanceTimeBy(150L)
+
+        composeTestRule.onNodeWithTag("button").performClick()
+        assertEquals(2, clickCount)
+    }
+
+    @Test
+    fun `When disabled, it does not register the click`() {
+        var clickCount = 0
+        composeTestRule.setContent {
+            Box(
+                modifier = Modifier
+                    .testTag("button")
+                    .throttleClickable(enabled = false) { clickCount++ }
+            )
+        }
+
+        composeTestRule.onNodeWithTag("button").performClick()
+
+        assertEquals(0, clickCount)
+    }
+
+    // endregion
+
+    // region throttleClickable (with interactionSource and indication)
+
+    @Test
+    fun `When clicking once with interactionSource, it registers the click`() {
+        var clickCount = 0
+        composeTestRule.setContent {
+            val interactionSource = remember { MutableInteractionSource() }
+            Box(
+                modifier = Modifier
+                    .testTag("button")
+                    .throttleClickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                    ) { clickCount++ }
+            )
+        }
+
+        composeTestRule.onNodeWithTag("button").performClick()
+
+        assertEquals(1, clickCount)
+    }
+
+    @Test
+    fun `When clicking rapidly with interactionSource, it registers only the first click`() {
+        var clickCount = 0
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            val interactionSource = remember { MutableInteractionSource() }
+            Box(
+                modifier = Modifier
+                    .testTag("button")
+                    .throttleClickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                    ) { clickCount++ }
+            )
+        }
+
+        composeTestRule.onNodeWithTag("button")
+            .performClick()
+            .performClick()
+            .performClick()
+
+        assertEquals(1, clickCount)
+    }
+
+    @Test
+    fun `When clicking after the interval has passed with interactionSource, it registers the click again`() {
+        var clickCount = 0
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            val interactionSource = remember { MutableInteractionSource() }
+            Box(
+                modifier = Modifier
+                    .testTag("button")
+                    .throttleClickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        intervalMillis = 100L,
+                    ) { clickCount++ }
+            )
+        }
+
+        composeTestRule.onNodeWithTag("button").performClick()
+        assertEquals(1, clickCount)
+
+        composeTestRule.mainClock.advanceTimeBy(150L)
+
+        composeTestRule.onNodeWithTag("button").performClick()
+        assertEquals(2, clickCount)
+    }
+
+    @Test
+    fun `When disabled with interactionSource, it does not register the click`() {
+        var clickCount = 0
+        composeTestRule.setContent {
+            val interactionSource = remember { MutableInteractionSource() }
+            Box(
+                modifier = Modifier
+                    .testTag("button")
+                    .throttleClickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        enabled = false,
+                    ) { clickCount++ }
+            )
+        }
+
+        composeTestRule.onNodeWithTag("button").performClick()
+
+        assertEquals(0, clickCount)
+    }
+
+    // endregion
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # SDK versions
 androidCompileSdk = "36"
-androidMinSdk = "21"
+androidMinSdk = "23"
 androidTargetSdk = "36"
 androidVersionCode = "1"
 androidVersionName = "1.0.0"
@@ -9,6 +9,7 @@ libVersionName = "0.2.0"
 
 androidx-appcompat = "1.7.1"
 androidx-core-ktx = "1.17.0"
+compose-bom = "2026.03.01"
 androidx-test-espresso = "3.7.0"
 androidx-test-junit = "1.3.0"
 detekt = "1.23.8"
@@ -17,6 +18,7 @@ gson = "2.13.2"
 hamcrest = "3.0"
 junit = "4.13.2"
 kotlin = "2.2.21"
+robolectric = "4.16.1"
 kover = "0.9.3"
 material = "1.13.0"
 
@@ -33,6 +35,13 @@ test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core",
 test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
 test-hamcrest = { group = "org.hamcrest", name = "hamcrest-library", version.ref = "hamcrest" }
 test-junit = { group = "junit", name = "junit", version.ref = "junit" }
+test-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+
+# Compose
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
 # Utilities
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
@@ -43,4 +52,5 @@ android-application = { id = "com.android.application", version.ref = "gradle" }
 android-library = { id = "com.android.library", version.ref = "gradle" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
https://github.com/nimblehq/android-common-ktx/issues/49

## What happened 👀

- [x] Enable compose for common-ktx module
- [x] Add new throttle click extension in ModifierExt 
- [x] Add UnitTest 

## Insight 📝

> [!NOTE]
> This PR only handle throttle click because throttle navigation events require BaseNavigationEvent that we don't have on this project. We will need to find alternative approach to cover later.

## Proof Of Work 📹

All test passed ✅ 

<img width="1650" height="477" alt="image" src="https://github.com/user-attachments/assets/db637c69-bdbb-4738-9e5d-a27e2faa635b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added throttled click modifier extension for Jetpack Compose, preventing multiple rapid clicks within a configurable interval (default 500ms).

* **Chores**
  * Updated minimum SDK version from 21 to 23.
  * Enhanced build system with Compose framework integration and improved test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->